### PR TITLE
Add clear function for BitFlyer

### DIFF
--- a/src/exchange/exchange.controller.ts
+++ b/src/exchange/exchange.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get } from '@nestjs/common';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { BotRequest } from './entities/exchange';
 import { ExchangeService } from './exchange.service';
 import { assertIsString } from '../utils/helper';
@@ -20,5 +20,12 @@ export class ExchangeController {
     assertIsString(botReq.asset);
     assertIsString(botReq.denominator);
     return this.service.buy(botReq.asset, botReq.denominator, botReq.amount);
+  }
+
+  @Get('clear')
+  clearOrders(@Body() botReq: BotRequest): Observable<any> {
+    assertIsString(botReq.asset);
+    assertIsString(botReq.denominator);
+    return this.service.clear(botReq.asset, botReq.denominator);
   }
 }

--- a/src/exchange/exchange.service.ts
+++ b/src/exchange/exchange.service.ts
@@ -9,9 +9,9 @@ export abstract class ExchangeService {
     protected secretService: SecretsService,
   ) {}
 
-  abstract getPrice(ofProduct: string, priceIn: string): Observable<any>;
+  abstract getPrice(ofProduct: string, priceIn: string): any;
 
-  abstract getBalance(priceIn: string): Observable<any>;
+  abstract getBalance(priceIn: string): any;
 
   abstract buy(
     asset: string,
@@ -21,4 +21,6 @@ export abstract class ExchangeService {
   ): any;
 
   abstract sell(asset: string, sellFor: string, amount?: number): any;
+
+  abstract clear(asset: string, denominator: string): any;
 }

--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -39,6 +39,7 @@ export class BitFlyerExchange extends ExchangeService {
     }
     const apiKeyName: string = configs.settings['api_keyname'];
     const secretKeyName: string = configs.settings['secret_keyname'];
+
     secretService
       .getSecret(apiKeyName)
       .then((key) => {
@@ -231,10 +232,10 @@ export class BitFlyerExchange extends ExchangeService {
     return response;
   }
 
-  clear(pair: string): Observable<any> {
+  clear(asset: string, denominator: string): Observable<any> {
     const path = '/v1/me/cancelallchildorders';
     const requestBody = JSON.stringify({
-      product_code: pair,
+      product_code: `${asset}_${denominator}`,
     });
     const signature = this.createSignature('POST', path, requestBody);
     const response = this.httpService.post(this.baseURL + path, requestBody, {


### PR DESCRIPTION
## Why
Added clear order functionality to BitFlyer exchange to enable clearing of all existing orders for an asset pair.

## What
Now `exchange/clear` endpoint should be reachable.