### PR TITLE
Support enabling/disabling guard from env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
+      - GUARD=none

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start:dev": "nest start --debug 0.0.0.0:9229 --watch",
-    "start": "node dist/main",
+    "start": "node --unhandled-rejections=strict dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --detectOpenHandles",
     "test:watch": "jest --watch",
@@ -29,7 +29,8 @@
     "js-yaml": "^4.1.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.6.7"
+    "rxjs": "^6.6.7",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.6.0",

--- a/src/exchange/exchange.controller.ts
+++ b/src/exchange/exchange.controller.ts
@@ -3,7 +3,6 @@ import { Observable, of } from 'rxjs';
 import { BotRequest } from './entities/exchange';
 import { ExchangeService } from './exchange.service';
 import { assertIsString } from '../utils/helper';
-import { TradingViewGuard } from '../guard/tradingview.guard';
 import { ExchangeInterceptor } from '../guard/exchange.interceptor';
 
 @Controller('exchange')

--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -113,7 +113,6 @@ export class BitFlyerExchange extends ExchangeService {
         }
       }),
       catchError((err) => {
-        console.error(err.response.data);
         return throwError(err);
       }),
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,22 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { TradingViewGuard } from './guard/tradingview.guard';
+import 'source-map-support/register';
+
+const GUARDS = ['tradingview', 'none'].map((guard) => guard.toLowerCase());
+const GUARD_ERROR = `Authorization guard not specified. Set GUARD env variable to one of: ${GUARDS.toString()}`;
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalGuards(new TradingViewGuard());
+  switch (process.env.GUARD.toLowerCase()) {
+    case 'tradingview':
+      app.useGlobalGuards(new TradingViewGuard());
+      break;
+    case 'none':
+      break;
+    default:
+      throw new Error(GUARD_ERROR);
+  }
   await app.listen(process.env.PORT);
 }
 bootstrap();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5356,7 +5356,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.19:
+source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
## Why
Without a way to enable/disable guard, it can be difficult to switch between trading (where the bot receives commands from an exchange and needs a `Guard`) and stacking (where it's called by cron and doesn't need one.)

## What
add supports for `GUARD` env variable