### PR TITLE
Change endpoint decorators from get to post

### DIFF
--- a/src/exchange/exchange.controller.ts
+++ b/src/exchange/exchange.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Post, Get, UseInterceptors } from '@nestjs/common';
 import { Observable, of } from 'rxjs';
 import { BotRequest } from './entities/exchange';
 import { ExchangeService } from './exchange.service';
@@ -10,7 +10,7 @@ export class ExchangeController {
   constructor(private service: ExchangeService) {}
 
   @UseInterceptors(ExchangeInterceptor)
-  @Get('sell')
+  @Post('sell')
   async makeSellOrder(@Body() botReq: BotRequest): Promise<Observable<any>> {
     assertIsString(botReq.asset);
     assertIsString(botReq.denominator);
@@ -18,7 +18,7 @@ export class ExchangeController {
   }
 
   @UseInterceptors(ExchangeInterceptor)
-  @Get('buy')
+  @Post('buy')
   async makeBuyOrder(@Body() botReq: BotRequest): Promise<Observable<any>> {
     assertIsString(botReq.asset);
     assertIsString(botReq.denominator);
@@ -26,7 +26,7 @@ export class ExchangeController {
   }
 
   @UseInterceptors(ExchangeInterceptor)
-  @Get('clear')
+  @Post('clear')
   clearOrders(@Body() botReq: BotRequest): Observable<any> {
     assertIsString(botReq.asset);
     assertIsString(botReq.denominator);


### PR DESCRIPTION
## Why
Cloud scheduler does not support `body` for `GET` endpoints. This should solve the issue.