### PR TITLE
Add missing query parameter for ticker endpoint

### DIFF
--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -83,7 +83,9 @@ export class BitFlyerExchange extends ExchangeService {
 
   getPrice(ofProduct: string, priceIn: string): Observable<BitFlyerAsset> {
     const path = '/v1/ticker';
-    const response = this.httpService.get(`${this.baseURL}${path}`);
+    const response = this.httpService.get(
+      `${this.baseURL}${path}?product_code=${ofProduct}_${priceIn}`,
+    );
     const price = response.pipe(
       map((x) => x.data),
       map((x) => {


### PR DESCRIPTION
## What
Fix a bug where request url for `getPrice` is incomplete.