### PR TITLE
Add support for recurring dip order placement for BitFlyer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Service account
+test-service-account.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       - GUARD=none
       - EXCHANGE=binance
       - CONFIGFILE=config.binance.sample.yaml
+      - GOOGLE_APPLICATION_CREDENTIALS=/usr/src/app/test-service-account.json

--- a/src/exchange/entities/exchange.ts
+++ b/src/exchange/entities/exchange.ts
@@ -14,6 +14,9 @@ export interface BotRequest {
   price?: number | undefined;
   // Time of alert (aka. {{time}} in TradingView)
   time?: string | undefined;
+  // Dip buying configuration in terms of
+  // Y % buying power allocate to X % drop in price
+  dip?: Dip[] | undefined;
 }
 
 export interface Asset {
@@ -25,4 +28,14 @@ export interface Asset {
 export interface Balance {
   balances: Asset[];
   total: Asset;
+}
+
+export interface Dip {
+  percent: number;
+  allocation: number;
+}
+
+export enum OrderType {
+  Market = 'MARKET',
+  Limit = 'LIMIT',
 }

--- a/src/exchange/exchange.controller.binance.spec.ts
+++ b/src/exchange/exchange.controller.binance.spec.ts
@@ -7,7 +7,7 @@ import configuration from '../services/configs/configurations';
 import { BotConfigService } from '../services/configs/botconfigs.service';
 import { SecretsService } from '../services/secrets/secrets.service';
 import { of } from 'rxjs';
-import { BotRequest } from './entities/exchange';
+import { BotRequest, OrderType } from './entities/exchange';
 import { BinanceExchange } from './services/binance.service';
 
 describe('ExchangeController', () => {
@@ -125,7 +125,12 @@ describe('ExchangeController', () => {
     const response = await controller.makeBuyOrder(botReq);
 
     expect(getBalance).toBeCalledWith('BTC');
-    expect(buyService).toBeCalledWith('ETH', 'BTC', undefined);
+    expect(buyService).toBeCalledWith(
+      'ETH',
+      'BTC',
+      OrderType.Market,
+      undefined,
+    );
     expect(response).toEqual(orderResponse);
     done();
   });
@@ -141,7 +146,7 @@ describe('ExchangeController', () => {
     const response = await controller.makeBuyOrder(botRegWithAmount);
 
     expect(getBalance).not.toBeCalled();
-    expect(buyService).toBeCalledWith('ETH', 'BTC', 2);
+    expect(buyService).toBeCalledWith('ETH', 'BTC', OrderType.Market, 2);
     expect(response).toEqual(orderResponse);
     done();
   });

--- a/src/exchange/exchange.controller.bitflyer.spec.ts
+++ b/src/exchange/exchange.controller.bitflyer.spec.ts
@@ -8,7 +8,7 @@ import configuration from '../services/configs/configurations';
 import { BotConfigService } from '../services/configs/botconfigs.service';
 import { SecretsService } from '../services/secrets/secrets.service';
 import { of } from 'rxjs';
-import { BotRequest } from './entities/exchange';
+import { BotRequest, OrderType } from './entities/exchange';
 
 describe('ExchangeController', () => {
   let controller: ExchangeController;
@@ -23,6 +23,25 @@ describe('ExchangeController', () => {
     amount: undefined,
     price: undefined,
     time: undefined,
+  };
+
+  const dipReq: BotRequest = {
+    asset: 'BTC',
+    denominator: 'JPY',
+    dip: [
+      {
+        percent: 10,
+        allocation: 10,
+      },
+      {
+        percent: 20,
+        allocation: 20,
+      },
+      {
+        percent: 30,
+        allocation: 40,
+      },
+    ],
   };
 
   const allAsset = {
@@ -104,7 +123,12 @@ describe('ExchangeController', () => {
     const response = await controller.makeBuyOrder(botReq);
 
     expect(getBalance).toBeCalledWith('BTC');
-    expect(buyService).toBeCalledWith('ETH', 'BTC', undefined);
+    expect(buyService).toBeCalledWith(
+      'ETH',
+      'BTC',
+      OrderType.Market,
+      undefined,
+    );
     expect(response).toEqual(orderResponse);
     done();
   });
@@ -120,7 +144,7 @@ describe('ExchangeController', () => {
     const response = await controller.makeBuyOrder(botRegWithAmount);
 
     expect(getBalance).not.toBeCalled();
-    expect(buyService).toBeCalledWith('ETH', 'BTC', 2);
+    expect(buyService).toBeCalledWith('ETH', 'BTC', OrderType.Market, 2);
     expect(response).toEqual(orderResponse);
     done();
   });
@@ -152,6 +176,61 @@ describe('ExchangeController', () => {
     expect(getBalance).not.toBeCalled();
     expect(sellService).toBeCalledWith('ETH', 'BTC', 2);
     expect(response).toEqual(orderResponse);
+    done();
+  });
+
+  it('Should buy the dip', async (done) => {
+    jest.spyOn(httpClient, 'post').mockReturnValue(of(orderResponse));
+    const getBalance = jest
+      .spyOn(service, 'getBalance')
+      .mockReturnValueOnce(of(allAsset));
+    jest.spyOn(service, 'getPrice').mockReturnValue(
+      of({
+        amount: 50000,
+        currency_code: 'JPY',
+      }),
+    );
+    const buyService = jest.spyOn(service, 'bidDips');
+    const clearOrders = jest.spyOn(service, 'clear');
+    const response = await controller.makeBuyDipOrders(dipReq);
+
+    expect(getBalance).toBeCalled();
+    expect(clearOrders).toBeCalledTimes(1);
+    expect(buyService).toBeCalledWith(
+      dipReq.asset,
+      dipReq.denominator,
+      dipReq.dip,
+    );
+    expect(response).toEqual({ status: 200, data: 'OK' });
+    done();
+  });
+
+  it('Should not buy the dip when requests are failing', async (done) => {
+    jest.spyOn(httpClient, 'post').mockReturnValue(of(orderResponse));
+    const getBalance = jest
+      .spyOn(service, 'getBalance')
+      .mockReturnValueOnce(of(allAsset));
+    jest.spyOn(service, 'getPrice').mockImplementation(() => {
+      throw new Error('');
+    });
+    const buyService = jest.spyOn(service, 'bidDips');
+    const clearOrders = jest.spyOn(service, 'clear');
+    await expect(controller.makeBuyDipOrders(dipReq)).rejects.toThrow();
+
+    expect(getBalance).toBeCalled();
+    expect(clearOrders).toBeCalledTimes(2);
+    expect(buyService).toBeCalledWith(
+      dipReq.asset,
+      dipReq.denominator,
+      dipReq.dip,
+    );
+    done();
+  });
+
+  it('Should not buy the dip when request is wrong', async (done) => {
+    let failDipReq = Object.assign({}, dipReq);
+    failDipReq.dip = [];
+    await expect(controller.makeBuyDipOrders(failDipReq)).rejects.toThrow();
     done();
   });
 });

--- a/src/exchange/exchange.controller.bitflyer.spec.ts
+++ b/src/exchange/exchange.controller.bitflyer.spec.ts
@@ -129,7 +129,7 @@ describe('ExchangeController', () => {
       OrderType.Market,
       undefined,
     );
-    expect(response).toEqual(orderResponse);
+    expect(response).toEqual(orderResponse.data);
     done();
   });
 
@@ -145,7 +145,7 @@ describe('ExchangeController', () => {
 
     expect(getBalance).not.toBeCalled();
     expect(buyService).toBeCalledWith('ETH', 'BTC', OrderType.Market, 2);
-    expect(response).toEqual(orderResponse);
+    expect(response).toEqual(orderResponse.data);
     done();
   });
 
@@ -159,7 +159,7 @@ describe('ExchangeController', () => {
 
     expect(getBalance).toBeCalledWith('BTC');
     expect(sellService).toBeCalledWith('ETH', 'BTC', undefined);
-    expect(response).toEqual(orderResponse);
+    expect(response).toEqual(orderResponse.data);
     done();
   });
 
@@ -175,7 +175,7 @@ describe('ExchangeController', () => {
 
     expect(getBalance).not.toBeCalled();
     expect(sellService).toBeCalledWith('ETH', 'BTC', 2);
-    expect(response).toEqual(orderResponse);
+    expect(response).toEqual(orderResponse.data);
     done();
   });
 

--- a/src/exchange/exchange.controller.ts
+++ b/src/exchange/exchange.controller.ts
@@ -1,8 +1,8 @@
 import { Body, Controller, Post, Get, UseInterceptors } from '@nestjs/common';
 import { Observable, of } from 'rxjs';
-import { BotRequest } from './entities/exchange';
+import { BotRequest, OrderType } from './entities/exchange';
 import { ExchangeService } from './exchange.service';
-import { assertIsString } from '../utils/helper';
+import { assertIsString, assertIsEmpty } from '../utils/helper';
 import { ExchangeInterceptor } from '../guard/exchange.interceptor';
 
 @Controller('exchange')
@@ -31,6 +31,7 @@ export class ExchangeController {
     return this.service.buy(
       botReq.asset.trim(),
       botReq.denominator.trim(),
+      OrderType.Market,
       botReq.amount,
     );
   }
@@ -42,6 +43,20 @@ export class ExchangeController {
     assertIsString(botReq.asset);
     assertIsString(botReq.denominator);
     return this.service.clear(botReq.asset.trim(), botReq.denominator.trim());
+  }
+
+  @UseInterceptors(ExchangeInterceptor)
+  @Post('buythedip')
+  async makeBuyDipOrders(@Body() botReq: BotRequest): Promise<any> {
+    console.log(botReq);
+    assertIsString(botReq.asset);
+    assertIsString(botReq.denominator);
+    assertIsEmpty(botReq.dip);
+    return this.service.bidDips(
+      botReq.asset.trim(),
+      botReq.denominator.trim(),
+      botReq.dip,
+    );
   }
 
   @Get('health')

--- a/src/exchange/exchange.service.ts
+++ b/src/exchange/exchange.service.ts
@@ -24,7 +24,7 @@ export abstract class ExchangeService {
 
   abstract sell(asset: string, sellFor: string, amount?: number): any;
 
-  abstract bidDips(asset: string, using: string, dipConfig: Dip[]): any;
+  abstract bidDips?(asset: string, using: string, dipConfig: Dip[]): any;
 
   abstract clear(asset: string, denominator: string): any;
 }

--- a/src/exchange/exchange.service.ts
+++ b/src/exchange/exchange.service.ts
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs';
 import { HttpService, Injectable } from '@nestjs/common';
 import { SecretsService } from '../services/secrets/secrets.service';
+import { Dip, OrderType } from './entities/exchange';
 
 @Injectable()
 export abstract class ExchangeService {
@@ -16,11 +17,14 @@ export abstract class ExchangeService {
   abstract buy(
     asset: string,
     using: string,
+    mode?: OrderType,
     amount?: number,
-    stopLoss?: number,
+    price?: number,
   ): any;
 
   abstract sell(asset: string, sellFor: string, amount?: number): any;
+
+  abstract bidDips(asset: string, using: string, dipConfig: Dip[]): any;
 
   abstract clear(asset: string, denominator: string): any;
 }

--- a/src/exchange/services/binance.service.spec.ts
+++ b/src/exchange/services/binance.service.spec.ts
@@ -11,6 +11,7 @@ import configuration from '../../services/configs/configurations';
 import { BotConfigService } from '../../services/configs/botconfigs.service';
 import { SecretsService } from '../../services/secrets/secrets.service';
 import { BinanceExchange } from './binance.service';
+import { OrderType } from '../entities/exchange';
 
 describe('ExchangeService', () => {
   let service: BinanceExchange;
@@ -321,7 +322,7 @@ describe('ExchangeService', () => {
       .mockResolvedValueOnce(of(allAsset));
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
-    const result = await service.buy('DOGE', 'BTC', 0.01);
+    const result = await service.buy('DOGE', 'BTC', OrderType.Market, 0.01);
 
     expect(result).toEqual(orderResponse);
     expect(getBalance).not.toBeCalled();

--- a/src/exchange/services/binance.service.ts
+++ b/src/exchange/services/binance.service.ts
@@ -289,4 +289,7 @@ export class BinanceExchange extends ExchangeService {
 
     return response;
   }
+
+  // TODO: implement
+  bidDips: undefined;
 }

--- a/src/exchange/services/binance.service.ts
+++ b/src/exchange/services/binance.service.ts
@@ -19,7 +19,7 @@ import { ExchangeService } from '../exchange.service';
 import * as crypto from 'crypto';
 import { forkJoin } from 'rxjs';
 import { SecretsService } from '../../services/secrets/secrets.service';
-import { Asset, Balance } from '../entities/exchange';
+import { Asset, Balance, OrderType } from '../entities/exchange';
 
 /**
  * Notes about using binance testnet.
@@ -180,8 +180,9 @@ export class BinanceExchange extends ExchangeService {
   async buy(
     asset: string,
     using: string,
+    mode: OrderType = OrderType.Market,
     amount?: number,
-    stopLoss?: number,
+    price?: number,
   ): Promise<any> {
     /* get balance, compute total asset, allocate */
     /* if amount is not specified, getBalance and check rebalancing configuration */
@@ -210,7 +211,10 @@ export class BinanceExchange extends ExchangeService {
 
     const path = '/api/v3/order?';
     const timestamp = await this.getTime();
-    const query = `symbol=${asset}${using}&side=BUY&type=MARKET&quantity=${amount}&newOrderRespType=FULL&timestamp=${timestamp}`;
+    let query = `symbol=${asset}${using}&side=BUY&type=${mode}&quantity=${amount}&newOrderRespType=FULL&timestamp=${timestamp}`;
+    if (mode === OrderType.Limit) {
+      query = `${query}&price=${price}&timeInForce=GTC`;
+    }
     const signature = this.createSignature(query);
     const response = this.httpService
       .post(`${this.baseURL}${path}${query}&signature=${signature}`, null, {

--- a/src/exchange/services/bitflyer.entities.ts
+++ b/src/exchange/services/bitflyer.entities.ts
@@ -8,6 +8,7 @@ export interface BitFlyerSignature {
   'ACCESS-KEY': string;
   'ACCESS-TIMESTAMP': string;
   'ACCESS-SIGN': string;
+  'Content-Type': string;
 }
 
 export interface BitFlyerBalance {

--- a/src/exchange/services/bitflyer.service.spec.ts
+++ b/src/exchange/services/bitflyer.service.spec.ts
@@ -193,7 +193,7 @@ describe('ExchangeService', () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.sell('BTC', 'JPY');
 
-    expect(result).toEqual(orderResponse);
+    expect(result).toEqual(orderResponse.data);
     expect(getBalance).toBeCalledWith('JPY');
     expect(getBalance).toBeCalledTimes(1);
     done();
@@ -207,7 +207,7 @@ describe('ExchangeService', () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.sell('BTC', 'JPY', 0.01);
 
-    expect(result).toEqual(orderResponse);
+    expect(result).toEqual(orderResponse.data);
     expect(getBalance).not.toBeCalled();
     done();
   });
@@ -239,7 +239,7 @@ describe('ExchangeService', () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.buy('ETH', 'BTC', OrderType.Market);
 
-    expect(result).toEqual(orderResponse);
+    expect(result).toEqual(orderResponse.data);
     expect(getBalance).toBeCalledWith('BTC');
     expect(getBalance).toBeCalledTimes(1);
     done();
@@ -253,7 +253,7 @@ describe('ExchangeService', () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.buy('DOGE', 'BTC', OrderType.Market, 0.01);
 
-    expect(result).toEqual(orderResponse);
+    expect(result).toEqual(orderResponse.data);
     expect(getBalance).not.toBeCalled();
     done();
   });
@@ -284,7 +284,7 @@ describe('ExchangeService', () => {
       .mockReturnValueOnce(of(orderResponse));
     const result = await service.buy('ETH', 'BTC', OrderType.Market);
 
-    expect(result).toEqual(orderResponse);
+    expect(result).toEqual(orderResponse.data);
 
     expect(buyRequest).toHaveBeenCalledWith(
       expect.anything(),
@@ -327,9 +327,9 @@ describe('ExchangeService', () => {
 
     expect(buyLimit).toBeCalledTimes(3);
     expect(buyLimit.mock.calls.map((item) => item[3])).toEqual([
-      17360 * 0.1,
-      17360 * 0.2,
-      17360 * 0.4,
+      0.03858,
+      0.0868,
+      0.1984,
     ]);
     expect(buyLimit.mock.calls.map((item) => item[4])).toEqual([
       50000 * 0.9,

--- a/src/exchange/services/bitflyer.service.spec.ts
+++ b/src/exchange/services/bitflyer.service.spec.ts
@@ -11,6 +11,7 @@ import { ConfigModule } from '@nestjs/config';
 import configuration from '../../services/configs/configurations';
 import { BotConfigService } from '../../services/configs/botconfigs.service';
 import { SecretsService } from '../../services/secrets/secrets.service';
+import { OrderType } from '../entities/exchange';
 
 describe('ExchangeService', () => {
   let service: BitFlyerExchange;
@@ -236,7 +237,7 @@ describe('ExchangeService', () => {
       .mockReturnValue(of(allAsset));
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
-    const result = await service.buy('ETH', 'BTC');
+    const result = await service.buy('ETH', 'BTC', OrderType.Market);
 
     expect(result).toEqual(orderResponse);
     expect(getBalance).toBeCalledWith('BTC');
@@ -250,7 +251,7 @@ describe('ExchangeService', () => {
       .mockReturnValue(of('' as any));
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
-    const result = await service.buy('DOGE', 'BTC', 0.01);
+    const result = await service.buy('DOGE', 'BTC', OrderType.Market, 0.01);
 
     expect(result).toEqual(orderResponse);
     expect(getBalance).not.toBeCalled();
@@ -263,7 +264,7 @@ describe('ExchangeService', () => {
       .mockReturnValue(of(allAsset));
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
-    const result = service.buy('BTC', 'DOGE');
+    const result = service.buy('BTC', 'DOGE', OrderType.Market);
 
     expect(result).rejects.toThrow(
       new HttpException(
@@ -281,7 +282,7 @@ describe('ExchangeService', () => {
     const buyRequest = jest
       .spyOn(httpClient, 'post')
       .mockReturnValueOnce(of(orderResponse));
-    const result = await service.buy('ETH', 'BTC');
+    const result = await service.buy('ETH', 'BTC', OrderType.Market);
 
     expect(result).toEqual(orderResponse);
 
@@ -296,6 +297,46 @@ describe('ExchangeService', () => {
       }),
       expect.anything(),
     );
+    done();
+  });
+
+  it('should buy the dip', async (done) => {
+    jest.spyOn(service, 'getPrice').mockReturnValue(
+      of({
+        amount: 50000,
+        currency_code: 'JPY',
+      }),
+    );
+    jest.spyOn(service, 'getBalance').mockReturnValue(of(allAsset));
+    const buyLimit = jest.spyOn(service, 'buy');
+    jest.spyOn(httpClient, 'post').mockReturnValue(of(orderResponse));
+    const dipBought = await service.bidDips('BTC', 'JPY', [
+      {
+        percent: 10,
+        allocation: 10,
+      },
+      {
+        percent: 20,
+        allocation: 20,
+      },
+      {
+        percent: 30,
+        allocation: 40,
+      },
+    ]);
+
+    expect(buyLimit).toBeCalledTimes(3);
+    expect(buyLimit.mock.calls.map((item) => item[3])).toEqual([
+      17360 * 0.1,
+      17360 * 0.2,
+      17360 * 0.4,
+    ]);
+    expect(buyLimit.mock.calls.map((item) => item[4])).toEqual([
+      50000 * 0.9,
+      50000 * 0.8,
+      50000 * 0.7,
+    ]);
+    expect(dipBought).toEqual({ status: 200, data: 'OK' });
     done();
   });
 });

--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -24,6 +24,8 @@ import {
   BitFlyerBalance,
   BitFlyerSignature,
 } from './bitflyer.entities';
+import { Dip, OrderType } from '../entities/exchange';
+import { request } from 'express';
 
 @Injectable()
 export class BitFlyerExchange extends ExchangeService {
@@ -168,8 +170,9 @@ export class BitFlyerExchange extends ExchangeService {
   async buy(
     asset: string,
     using: string,
+    mode: OrderType = OrderType.Market,
     amount?: number,
-    stopLoss?: number,
+    price?: number,
   ): Promise<any> {
     /* get balance, compute total asset, allocate */
     /* if amount is not specified, getBalance and check rebalancing configuration */
@@ -198,16 +201,20 @@ export class BitFlyerExchange extends ExchangeService {
     }
 
     const path = '/v1/me/sendchildorder';
-    const requestBody = JSON.stringify({
+    let requestBody = {
       product_code: `${asset}_${using}`,
-      child_order_type: 'MARKET',
+      child_order_type: mode,
       side: 'BUY',
       size: amount,
       time_in_force: 'GTC',
-    });
-    const signature = this.createSignature('POST', path, requestBody);
+    };
+    if (mode === OrderType.Limit) {
+      requestBody = Object.assign({ price }, requestBody);
+    }
+    const requestBodyString = JSON.stringify(requestBody);
+    const signature = this.createSignature('POST', path, requestBodyString);
     const response = this.httpService
-      .post(this.baseURL + path, requestBody, {
+      .post(this.baseURL + path, requestBodyString, {
         headers: signature,
       })
       .pipe(
@@ -283,5 +290,35 @@ export class BitFlyerExchange extends ExchangeService {
       .toPromise();
 
     return response;
+  }
+
+  async bidDips(asset: string, using: string, dipConfig: Dip[]): Promise<any> {
+    try {
+      await this.clear(asset, using);
+      const myAsset = await this.getBalance(using).toPromise();
+      const assetPrice = await this.getPrice(asset, using).toPromise();
+      const buyingAsset = myAsset.balances.filter(
+        (item) => item.currency_code === using,
+      )[0];
+
+      await Promise.all(
+        dipConfig.map(async (dip) =>
+          this.buy(
+            asset,
+            using,
+            OrderType.Limit,
+            buyingAsset.available! * (dip.allocation / 100),
+            assetPrice.amount * (1 - dip.percent / 100),
+          ),
+        ),
+      );
+      return { status: 200, data: 'OK' };
+    } catch (err) {
+      await this.clear(asset, using);
+      throw new HttpException(
+        'Dip bids failed.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 }

--- a/src/services/secrets/secrets.service.ts
+++ b/src/services/secrets/secrets.service.ts
@@ -16,5 +16,4 @@ export class SecretsService {
     // @ts-ignore
     return accessResponse.payload.data.toString('utf8');
   }
-  j;
 }

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -5,3 +5,9 @@ export function assertIsString(val: any): asserts val is string {
     throw new AssertionError({ message: 'Not a string!' });
   }
 }
+
+export function assertIsEmpty(val: any[]): asserts val is any[] {
+  if (val.length < 1) {
+    throw new AssertionError({ message: 'Empty array!' });
+  }
+}


### PR DESCRIPTION
## Why
Due to recent liquidation crisis, I thought it might be a good opportunity to add a feature to plan for that in the future for those who'd like to buy the dip.

## What 
Add support for buying the dip on bitflyer. See the interface for `Dip` to plan your request body accordingly.