### PR TITLE
Add fixes for secret instatiation issue + tests

### DIFF
--- a/src/exchange/exchange.controller.binance.spec.ts
+++ b/src/exchange/exchange.controller.binance.spec.ts
@@ -98,29 +98,27 @@ describe('ExchangeController', () => {
     controller = new ExchangeController(service);
   });
 
-  it('Should throw when buy parameter type is not correct', async (done) => {
+  it('Should throw when buy parameter type is not correct', async () => {
     const result = controller.makeBuyOrder({
       asset: undefined,
       denominator: undefined,
     } as any);
-    expect(result).rejects.toThrow();
-    done();
+    await expect(result).rejects.toThrow();
   });
 
-  it('Should throw when sell parameter type is not correct', async (done) => {
+  it('Should throw when sell parameter type is not correct', async () => {
     const result = controller.makeSellOrder({
       asset: undefined,
       denominator: undefined,
     } as any);
-    expect(result).rejects.toThrow();
-    done();
+    await expect(result).rejects.toThrow();
   });
 
-  it('Should buy correctly when amount is undefined', async (done) => {
+  it('Should buy correctly when amount is undefined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const buyService = jest.spyOn(service, 'buy');
     const response = await controller.makeBuyOrder(botReq);
 
@@ -132,14 +130,13 @@ describe('ExchangeController', () => {
       undefined,
     );
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should buy correctly when amount is defined', async (done) => {
+  it('Should buy correctly when amount is defined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const buyService = jest.spyOn(service, 'buy');
     let botRegWithAmount = Object.assign({}, botReq);
     botRegWithAmount.amount = 2;
@@ -148,28 +145,26 @@ describe('ExchangeController', () => {
     expect(getBalance).not.toBeCalled();
     expect(buyService).toBeCalledWith('ETH', 'BTC', OrderType.Market, 2);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should sell correctly when amount is undefined', async (done) => {
+  it('Should sell correctly when amount is undefined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const sellService = jest.spyOn(service, 'sell');
     const response = await controller.makeSellOrder(botReq);
 
     expect(getBalance).toBeCalledWith('BTC');
     expect(sellService).toBeCalledWith('ETH', 'BTC', undefined);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should sell correctly when amount is defined', async (done) => {
+  it('Should sell correctly when amount is defined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const sellService = jest.spyOn(service, 'sell');
     let botRegWithAmount = Object.assign({}, botReq);
     botRegWithAmount.amount = 2;
@@ -178,6 +173,5 @@ describe('ExchangeController', () => {
     expect(getBalance).not.toBeCalled();
     expect(sellService).toBeCalledWith('ETH', 'BTC', 2);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 });

--- a/src/exchange/exchange.controller.bitflyer.spec.ts
+++ b/src/exchange/exchange.controller.bitflyer.spec.ts
@@ -96,29 +96,27 @@ describe('ExchangeController', () => {
     controller = new ExchangeController(service);
   });
 
-  it('Should throw when buy parameter type is not correct', async (done) => {
+  it('Should throw when buy parameter type is not correct', async () => {
     const result = controller.makeBuyOrder({
       asset: undefined,
       denominator: undefined,
     } as any);
     expect(result).rejects.toThrow();
-    done();
   });
 
-  it('Should throw when sell parameter type is not correct', async (done) => {
+  it('Should throw when sell parameter type is not correct', async () => {
     const result = controller.makeSellOrder({
       asset: undefined,
       denominator: undefined,
     } as any);
     expect(result).rejects.toThrow();
-    done();
   });
 
-  it('Should buy correctly when amount is undefined', async (done) => {
+  it('Should buy correctly when amount is undefined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const buyService = jest.spyOn(service, 'buy');
     const response = await controller.makeBuyOrder(botReq);
 
@@ -130,14 +128,13 @@ describe('ExchangeController', () => {
       undefined,
     );
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should buy correctly when amount is defined', async (done) => {
+  it('Should buy correctly when amount is defined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const buyService = jest.spyOn(service, 'buy');
     let botRegWithAmount = Object.assign({}, botReq);
     botRegWithAmount.amount = 2;
@@ -146,28 +143,26 @@ describe('ExchangeController', () => {
     expect(getBalance).not.toBeCalled();
     expect(buyService).toBeCalledWith('ETH', 'BTC', OrderType.Market, 2);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should sell correctly when amount is undefined', async (done) => {
+  it('Should sell correctly when amount is undefined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const sellService = jest.spyOn(service, 'sell');
     const response = await controller.makeSellOrder(botReq);
 
     expect(getBalance).toBeCalledWith('BTC');
     expect(sellService).toBeCalledWith('ETH', 'BTC', undefined);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should sell correctly when amount is defined', async (done) => {
+  it('Should sell correctly when amount is defined', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     const sellService = jest.spyOn(service, 'sell');
     let botRegWithAmount = Object.assign({}, botReq);
     botRegWithAmount.amount = 2;
@@ -176,14 +171,13 @@ describe('ExchangeController', () => {
     expect(getBalance).not.toBeCalled();
     expect(sellService).toBeCalledWith('ETH', 'BTC', 2);
     expect(response).toEqual(orderResponse.data);
-    done();
   });
 
-  it('Should buy the dip', async (done) => {
+  it('Should buy the dip', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValue(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     jest.spyOn(service, 'getPrice').mockReturnValue(
       of({
         amount: 50000,
@@ -202,14 +196,13 @@ describe('ExchangeController', () => {
       dipReq.dip,
     );
     expect(response).toEqual({ status: 200, data: 'OK' });
-    done();
   });
 
-  it('Should not buy the dip when requests are failing', async (done) => {
+  it('Should not buy the dip when requests are failing', async () => {
     jest.spyOn(httpClient, 'post').mockReturnValue(of(orderResponse));
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockReturnValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
     jest.spyOn(service, 'getPrice').mockImplementation(() => {
       throw new Error('');
     });
@@ -224,13 +217,11 @@ describe('ExchangeController', () => {
       dipReq.denominator,
       dipReq.dip,
     );
-    done();
   });
 
-  it('Should not buy the dip when request is wrong', async (done) => {
+  it('Should not buy the dip when request is wrong', async () => {
     let failDipReq = Object.assign({}, dipReq);
     failDipReq.dip = [];
     await expect(controller.makeBuyDipOrders(failDipReq)).rejects.toThrow();
-    done();
   });
 });

--- a/src/exchange/services/binance.service.spec.ts
+++ b/src/exchange/services/binance.service.spec.ts
@@ -229,7 +229,7 @@ describe('ExchangeService', () => {
     );
     jest.spyOn(httpClient, 'get').mockReturnValueOnce(of(balanceResponse));
     const result = await service.getBalance('BTC');
-    result.subscribe({
+    of(result).subscribe({
       next: (x) => {
         expect(x.balances).toMatchObject(allAsset.balances);
       },
@@ -245,9 +245,9 @@ describe('ExchangeService', () => {
       }),
     );
     jest.spyOn(httpClient, 'get').mockReturnValueOnce(of(balanceResponse));
-    const result = from(await service.getBalance('BTC'));
+    const result = await service.getBalance('BTC');
 
-    result.subscribe({
+    of(result).subscribe({
       next: (x) => {
         expect(x.total.amount).toBeCloseTo(1.09329668);
         expect(x.total.currency_code).toBe('BTC');
@@ -256,10 +256,10 @@ describe('ExchangeService', () => {
     });
   });
 
-  it('should find the amount of asset to sell when not specified', async (done) => {
+  it('should find the amount of asset to sell when not specified', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.sell('BTC', 'USDT');
@@ -267,31 +267,29 @@ describe('ExchangeService', () => {
     expect(result).toEqual(orderResponse.data);
     expect(getBalance).toBeCalledWith('USDT');
     expect(getBalance).toBeCalledTimes(1);
-    done();
   });
 
-  it('should not find the amount of asset to sell when specified', async (done) => {
+  it('should not find the amount of asset to sell when specified', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of('' as any));
+      .mockResolvedValueOnce('' as any);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.sell('BTC', 'USDT', 0.01);
 
     expect(result).toEqual(orderResponse.data);
     expect(getBalance).not.toBeCalled();
-    done();
   });
 
-  it('should throw when asset to sell is not found', async (done) => {
+  it('should throw when asset to sell is not found', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = service.sell('SAFEMOON', 'USDT');
 
-    expect(result).rejects.toThrow(
+    await expect(result).rejects.toThrow(
       new HttpException(
         'Could not find an asset to sell.',
         HttpStatus.BAD_REQUEST,
@@ -299,13 +297,12 @@ describe('ExchangeService', () => {
     );
     expect(getBalance).toBeCalledWith('USDT');
     expect(getBalance).toBeCalledTimes(1);
-    done();
   });
 
-  it('should find the amount of asset to buy when not specified', async (done) => {
+  it('should find the amount of asset to buy when not specified', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.buy('ETH', 'BTC');
@@ -313,31 +310,29 @@ describe('ExchangeService', () => {
     expect(result).toEqual(orderResponse.data);
     expect(getBalance).toBeCalledWith('BTC');
     expect(getBalance).toBeCalledTimes(1);
-    done();
   });
 
-  it('should not find the amount of asset to buy when specified', async (done) => {
+  it('should not find the amount of asset to buy when specified', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = await service.buy('DOGE', 'BTC', OrderType.Market, 0.01);
 
     expect(result).toEqual(orderResponse.data);
     expect(getBalance).not.toBeCalled();
-    done();
   });
 
-  it('should throw when asset to buy with is not found', async (done) => {
+  it('should throw when asset to buy with is not found', async () => {
     const getBalance = jest
       .spyOn(service, 'getBalance')
-      .mockResolvedValueOnce(of(allAsset));
+      .mockResolvedValueOnce(allAsset);
 
     jest.spyOn(httpClient, 'post').mockReturnValueOnce(of(orderResponse));
     const result = service.buy('BTC', 'DOGE');
 
-    expect(result).rejects.toThrow(
+    await expect(result).rejects.toThrow(
       new HttpException(
         'Could not calculate total available asset',
         HttpStatus.INTERNAL_SERVER_ERROR,
@@ -345,11 +340,10 @@ describe('ExchangeService', () => {
     );
     expect(getBalance).toBeCalledWith('DOGE');
     expect(getBalance).toBeCalledTimes(1);
-    done();
   });
 
-  it('should rebalance correctly when amount is not specified', async (done) => {
-    jest.spyOn(service, 'getBalance').mockResolvedValueOnce(of(allAsset));
+  it('should rebalance correctly when amount is not specified', async () => {
+    jest.spyOn(service, 'getBalance').mockResolvedValueOnce(allAsset);
     const buyRequest = jest
       .spyOn(httpClient, 'post')
       .mockReturnValueOnce(of(orderResponse));
@@ -362,6 +356,5 @@ describe('ExchangeService', () => {
       null,
       expect.anything(),
     );
-    done();
   });
 });

--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -205,7 +205,11 @@ export class BitFlyerExchange extends ExchangeService {
       requestBody = Object.assign({ price }, requestBody);
     }
     const requestBodyString = JSON.stringify(requestBody);
-    const signature = this.createSignature('POST', path, requestBodyString);
+    const signature = await this.createSignature(
+      'POST',
+      path,
+      requestBodyString,
+    );
     const response = this.httpService
       .post(this.baseURL + path, requestBodyString, {
         headers: signature,
@@ -249,7 +253,7 @@ export class BitFlyerExchange extends ExchangeService {
       size: amount,
       time_in_force: 'GTC',
     });
-    const signature = this.createSignature('POST', path, requestBody);
+    const signature = await this.createSignature('POST', path, requestBody);
     const response = this.httpService
       .post(this.baseURL + path, requestBody, {
         headers: signature,
@@ -271,7 +275,7 @@ export class BitFlyerExchange extends ExchangeService {
     const requestBody = JSON.stringify({
       product_code: `${asset}_${denominator}`,
     });
-    const signature = this.createSignature('POST', path, requestBody);
+    const signature = await this.createSignature('POST', path, requestBody);
     const response = this.httpService
       .post(this.baseURL + path, requestBody, {
         headers: signature,

--- a/src/exchange/services/bitflyer.service.ts
+++ b/src/exchange/services/bitflyer.service.ts
@@ -43,29 +43,24 @@ export class BitFlyerExchange extends ExchangeService {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
-    const apiKeyName: string = configs.settings['api_keyname'];
-    const secretKeyName: string = configs.settings['secret_keyname'];
-
-    secretService
-      .getSecret(apiKeyName)
-      .then((key) => {
-        this.key = key;
-      })
-      .catch((error) => console.error(error));
-
-    secretService
-      .getSecret(secretKeyName)
-      .then((key) => {
-        this.secret = key;
-      })
-      .catch((error) => console.error(error));
   }
 
-  private createSignature(
+  private async initSecrets(): Promise<void> {
+    const apiKeyName: string = this.configs.settings['api_keyname'];
+    const secretKeyName: string = this.configs.settings['secret_keyname'];
+
+    if (this.secret === '' || this.key === '') {
+      this.key = await this.secretService.getSecret(apiKeyName);
+      this.secret = await this.secretService.getSecret(secretKeyName);
+    }
+  }
+
+  private async createSignature(
     method: string,
     path: string,
     body?: string,
-  ): BitFlyerSignature {
+  ): Promise<BitFlyerSignature> {
+    await this.initSecrets();
     const timestamp = Date.now().toString();
     const bodyString = body ?? '';
     const text = timestamp + method + path + bodyString;
@@ -121,9 +116,9 @@ export class BitFlyerExchange extends ExchangeService {
     return price;
   }
 
-  getBalance(priceIn: string): Observable<BitFlyerBalance> {
+  async getBalance(priceIn: string): Promise<BitFlyerBalance> {
     const path = '/v1/me/getbalance';
-    const signature = this.createSignature('GET', path);
+    const signature = await this.createSignature('GET', path);
     const response = this.httpService.get(`${this.baseURL}${path}`, {
       headers: signature,
     });
@@ -162,7 +157,7 @@ export class BitFlyerExchange extends ExchangeService {
     return forkJoin({
       balances,
       total,
-    });
+    }).toPromise();
   }
 
   async buy(
@@ -176,7 +171,7 @@ export class BitFlyerExchange extends ExchangeService {
     /* if amount is not specified, getBalance and check rebalancing configuration */
     if (amount === undefined) {
       try {
-        const myAsset = await this.getBalance(using)
+        const myAsset = await of(await this.getBalance(using))
           .pipe(
             map((x) => x.total),
             filter((x) => x.currency_code === using),
@@ -230,7 +225,7 @@ export class BitFlyerExchange extends ExchangeService {
   async sell(asset: string, sellFor: string, amount?: number): Promise<any> {
     if (amount === undefined) {
       try {
-        const myAsset = await this.getBalance(sellFor)
+        const myAsset = await of(await this.getBalance(sellFor))
           .pipe(
             mergeMap((x) => x.balances),
             filter((x) => x['currency_code'] === asset),
@@ -271,7 +266,7 @@ export class BitFlyerExchange extends ExchangeService {
     return response;
   }
 
-  clear(asset: string, denominator: string): Promise<any> {
+  async clear(asset: string, denominator: string): Promise<any> {
     const path = '/v1/me/cancelallchildorders';
     const requestBody = JSON.stringify({
       product_code: `${asset}_${denominator}`,
@@ -296,7 +291,7 @@ export class BitFlyerExchange extends ExchangeService {
   async bidDips(asset: string, using: string, dipConfig: Dip[]): Promise<any> {
     try {
       await this.clear(asset, using);
-      const myAsset = await this.getBalance(using).toPromise();
+      const myAsset = await this.getBalance(using);
       const assetPrice = await this.getPrice(asset, using).toPromise();
       const buyingAsset = myAsset.balances.filter(
         (item) => item.currency_code === using,


### PR DESCRIPTION
## Why
This PR fixes a bug where APIs were called before the module finishes instantiating secret keys from secret managers.

## What
Ensure that keys were properly instantiated during signature creation phase. This changes `createSignature` to be async and therefore necessitate changes in other areas that relies on the function.