### PR TITLE
Fix binance lot size issue

### DIFF
--- a/src/services/configs/config.binance.sample.yaml
+++ b/src/services/configs/config.binance.sample.yaml
@@ -8,7 +8,7 @@ configurations:
     - 'LINK:15'
     - 'ADA:10'
   trading_pairs:
-    - 'BTC:USDT'
+    - 'BTC:USDC'
     - 'ETH:BTC'
     - 'LINK:BTC'
     - 'ADA:BTC'


### PR DESCRIPTION
## What
- [Issue](https://github.com/binance-exchange/binance-java-api/issues/44) here indicates that we would need to compute buy/sell amount according to the lot size's minimum quantity and step size when making purchases via the api.
- Added `getLotInfo` in binance service to allow for such capability.
- Fixed a bug where purchasing amount is calculated incorrectly
- Added tests for `getLotInfo`